### PR TITLE
Update include.gradle

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -4,5 +4,5 @@ android {
 }
 
 dependencies {
-	implementation 'com.facebook.android:facebook-android-sdk:[5,6)'
+	implementation 'com.facebook.android:facebook-android-sdk:latest.release'
 }


### PR DESCRIPTION
Facebook has terminated support for embedded browsers on android SDK lower than version 8.2.

My proposed change sets it to use the latest released SDK to help bypass this issue.